### PR TITLE
Add missing packages to docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,16 @@ FROM python:3.7-slim
 
 RUN pip install pipenv
 
-RUN groupadd --gid 1000 dev-tools && \
+    # Apt packages are required to run gcloud commands for whitelisting
+RUN apt-get update && \
+    apt-get -yq install curl && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    apt-get -yq install apt-transport-https ca-certificates gnupg && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update && apt-get -yq install google-cloud-sdk && \
+    apt-get -yq install kubectl && \
+    apt-get -yq clean && \
+    groupadd --gid 1000 dev-tools && \
     useradd --create-home --system --uid 1000 --gid dev-tools dev-tools
 WORKDIR /home/dev-tools
 


### PR DESCRIPTION
# Motivation and Context
gcloud-sdk packages are required for the whitelisting scripts

# What has changed
* Add missing packages to dockerfile

# How to test?
Check the packages are there

# Links
https://trello.com/c/XHfzQUze/1257-split-cloudshell-utilities-and-monitoring-tools-out-of-census-rm-toolbox
