### PR TITLE
Add terraform/helm setup script/instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See https://cloud.google.com/shell/docs for help on cloudshell basics and docume
 
 ### Clone this repo
 ```shell script
-git clone https://github.com/ONSdigital/census-rm-dev-tools.git
+git clone https://github.com/ONSdigital/census-rm-dev-tools.git ~/census-rm-dev-tools
 ```
 
 ### Set up python and dev/support shortcuts

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ dewhitelist
 We use terraform (via tfenv) and helm v2 with the tillerless plugin for our infrastructure management, these are the steps to set up those tools on your cloudshell. This is only necessary if you need to be able to make infrastructure changes.
 
 #### Creating a github personal token
-Clone the terraform repo with
 The easiest way to clone the terraform repo on a cloudshell is with a personal token. Follow the steps here https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token and create a token with only "repo" permissions.
-**Do not** store this token anywhere. If you need to clone or pull the repo again just regenerate the token. Copy the token, you'll need it for the next step.
+**Do not** store this token anywhere, treat it like a password. If you need to clone or pull the repo again you can regenerate the token. 
+Copy the token, you'll need it for the next step.
 
 #### Run the setup script
 ```shell script
@@ -71,7 +71,7 @@ pushd ~/census-rm-dev-tools
 popd
 ```
 The first thing this does is attempt to clone our terraform repo. You will be prompted for your github username and password. Enter your username as normal but paste the access token in the place of the password.
-It then installs `tfenv` and `helm v2` plus the tillerless plugin. The first time you run any terraform commands, `tfenv` should automatically install and use the required `terraform cli` version.
+It then installs `tfenv` and `helm v2` plus the tillerless plugin. The first time you run any of the terraform scripts, `tfenv` should automatically install and use the required `terraform cli` version.
 
 #### Checking out a terraform release
 If you need to run terraform at a tagged version run

--- a/README.md
+++ b/README.md
@@ -56,6 +56,33 @@ It is then important to:
 dewhitelist
 ```
 
+### Terraform and Helm
+We use terraform (via tfenv) and helm v2 with the tillerless plugin for our infrastructure management, these are the steps to set up those tools on your cloudshell. This is only necessary if you need to be able to make infrastructure changes.
+
+#### Creating a github personal token
+Clone the terraform repo with
+The easiest way to clone the terraform repo on a cloudshell is with a personal token. Follow the steps here https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token and create a token with only "repo" permissions.
+**Do not** store this token anywhere. If you need to clone or pull the repo again just regenerate the token. Copy the token, you'll need it for the next step.
+
+#### Run the setup script
+```shell script
+pushd ~/census-rm-dev-tools
+./cloudshell_setup/setup_terraform_and_helm.sh
+popd
+```
+The first thing this does is attempt to clone our terraform repo. You will be prompted for your github username and password. Enter your username as normal but paste the access token in the place of the password.
+It then installs `tfenv` and `helm v2` plus the tillerless plugin. The first time you run any terraform commands, `tfenv` should automatically install and use the required `terraform cli` version.
+
+#### Checking out a terraform release
+If you need to run terraform at a tagged version run
+```shell script
+cd ~/census-rm-terraform
+git checkout <TAG>
+```
+This should prompt you again for your github credentials so you'll need to regenerate your access token from earlier. Navigate to the token you created in your github developer settings and click `regenerate token` and copy the regenerated token.
+Paste the token in place of your password again and it should check out the tag you passed in.
+
+
 ## Work From Home (WFH) Whitelist Script
 To whitelist yourself on White Lodge and Black Lodge clusters and DB, plus a bunch of other things, run this script:
 ```bash

--- a/cloudshell_setup/bash_tools.sh
+++ b/cloudshell_setup/bash_tools.sh
@@ -1,6 +1,6 @@
 
 # Dev tools
-export PATH="~/census-rm-dev-tools:$PATH"
+export PATH="$HOME/census-rm-dev-tools:$PATH"
 alias set-project="gcloud config set project"
 
 function whitelist {

--- a/cloudshell_setup/bash_tools.sh
+++ b/cloudshell_setup/bash_tools.sh
@@ -1,6 +1,6 @@
 
 # Dev tools
-export PATH="/home/adam_hawtin/census-rm-dev-tools:$PATH"
+export PATH="~/census-rm-dev-tools:$PATH"
 alias set-project="gcloud config set project"
 
 function whitelist {

--- a/cloudshell_setup/setup_python_and_tools.sh
+++ b/cloudshell_setup/setup_python_and_tools.sh
@@ -7,12 +7,14 @@ echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
 echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 source ~/.bashrc
 
+# Install an up to date python 3, pipenv and then create the pipenv for the dev-tools
 echo "Installing python 3.8.5, this might take several minutes..."
 pyenv install 3.8.5
 pyenv global 3.8.5
 pip install -U pip pipenv
 pipenv install --dev
 
+# Add tools/shortcuts to shell
 cat cloudshell_setup/bash_tools.sh >> ~/.bashrc
 
 exec "$SHELL"

--- a/cloudshell_setup/setup_terraform_and_helm.sh
+++ b/cloudshell_setup/setup_terraform_and_helm.sh
@@ -1,0 +1,16 @@
+git clone https://github.com/ONSdigital/census-rm-terraform.git ~/census-rm-terraform
+
+git clone https://github.com/tfutils/tfenv.git ~/.tfenv
+echo 'PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+tfenv --version
+
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get
+chmod 700 get_helm.sh
+./get_helm.sh
+helm init --client-only
+helm plugin install https://github.com/rimusz/helm-tiller
+
+helm version
+
+exec bash

--- a/cloudshell_setup/setup_terraform_and_helm.sh
+++ b/cloudshell_setup/setup_terraform_and_helm.sh
@@ -11,6 +11,6 @@ chmod 700 get_helm.sh
 helm init --client-only
 helm plugin install https://github.com/rimusz/helm-tiller
 
-helm version
+helm version --client
 
 exec bash

--- a/cloudshell_setup/setup_terraform_and_helm.sh
+++ b/cloudshell_setup/setup_terraform_and_helm.sh
@@ -15,4 +15,4 @@ helm init --client-only
 helm plugin install https://github.com/rimusz/helm-tiller
 helm version --client
 
-exec bash
+exec "$SHELL"

--- a/cloudshell_setup/setup_terraform_and_helm.sh
+++ b/cloudshell_setup/setup_terraform_and_helm.sh
@@ -1,16 +1,18 @@
+# Clone our terraform repo
 git clone https://github.com/ONSdigital/census-rm-terraform.git ~/census-rm-terraform
 
+# Install Tfenv
 git clone https://github.com/tfutils/tfenv.git ~/.tfenv
 echo 'PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 tfenv --version
 
+# Install helm 2 and helm-tiller plugin
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get
 chmod 700 get_helm.sh
 ./get_helm.sh
 helm init --client-only
 helm plugin install https://github.com/rimusz/helm-tiller
-
 helm version --client
 
 exec bash


### PR DESCRIPTION
# Motivation and Context
We need the capability to run terraform/helm from cloudshell.

# What has changed
* Add terraform/helm setup script/instructions
* Fix a couple of mistakes

# How to test?
Run through the new instructions then try terraforming your dev environment from your cloudshell

# Links
https://trello.com/c/Qw8jaBZM/1386-document-script-terraform-helm-installation-on-cloudshell
